### PR TITLE
Fixed PlgxTools building failure and added support for Visual Studio 2017

### DIFF
--- a/KeePassPluginDevTools.sln
+++ b/KeePassPluginDevTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SamplePlugin", "SamplePlugin\SamplePlugin.csproj", "{4B5B8E16-3542-4997-8BF3-2DFFF5E9F1C2}"
 EndProject
@@ -143,6 +143,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {34BC3374-C348-42FC-AB5F-C9C7422942DA}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = PlgxTools\PlgxTools.csproj

--- a/PlgxTools/Microsoft.Build.Plgx.xsd
+++ b/PlgxTools/Microsoft.Build.Plgx.xsd
@@ -3,8 +3,11 @@
  xmlns:msb="http://schemas.microsoft.com/developer/msbuild/2003"
  targetNamespace="http://schemas.microsoft.com/developer/msbuild/2003"
  elementFormDefault="qualified">
-  <xs:include schemaLocation="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Xml\Schemas\1033\Microsoft.Build.xsd" />
-
+  <!-- <xs:include schemaLocation="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Xml\Schemas\1033\Microsoft.Build.xsd" /> -->
+  
+  <!-- Support for Visual Studio 2017 Community -->
+  <xs:include schemaLocation="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Xml\Schemas\1033\Microsoft.Build.xsd" />
+  
   <!-- Extend Microsoft.Build.xsd to include properties used by PlgxTool.targets -->
   <!-- Also see: http://keepass.info/help/v2_dev/plg_index.html#plgx -->
 

--- a/PlgxTools/PlgxTool.csproj
+++ b/PlgxTools/PlgxTool.csproj
@@ -76,18 +76,16 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="GetXsdExe">
     <!-- based on http://connect.microsoft.com/VisualStudio/feedback/details/583931/xsd-exe-should-be-accessible-from-ide-builds -->
-    <GetFrameworkSdkPath>
-      <Output TaskParameter="Path" PropertyName="SdkPath" />
-    </GetFrameworkSdkPath>
-    <CreateProperty Condition="'$(OS)' == 'Windows_NT'" Value="$(SdkPath)bin\NETFX 4.0 Tools\xsd.exe">
+    <Error Condition="'$(SDK40ToolsPath)'==''" Text="Missing SDK40ToolsPath property." />
+    <Error Condition="!Exists('$(SDK40ToolsPath)xsd.exe')" Text="xsd.exe cannot be found at SDK40ToolsPath: $(SDK40ToolsPath)xsd.exe." />
+    <CreateProperty Condition="'$(OS)' == 'Windows_NT'" Value="&quot;$(SDK40ToolsPath)xsd.exe&quot;">
       <Output TaskParameter="Value" PropertyName="XsdExe" />
     </CreateProperty>
     <CreateProperty Condition="'$(OS)' != 'Windows_NT'" Value="xsd">
       <Output TaskParameter="Value" PropertyName="XsdExe" />
     </CreateProperty>
   </Target>
-  <Target Name="BeforeBuild">
-    <CallTarget Targets="GetXsdExe" />
+  <Target Name="BeforeBuild" DependsOnTargets="GetXsdExe">
     <Exec Command="$(XsdExe) Microsoft.Build.Plgx.xsd /c /n:$(RootNamespace)" />
   </Target>
   <Target Name="AfterClean">

--- a/PlgxTools/Program.cs
+++ b/PlgxTools/Program.cs
@@ -219,7 +219,7 @@ namespace KeePassPluginDevTools.PlgxTools
               // loop if we need to
               var children = itemGroup.ChildNodes.Cast<XmlNode>().Where(child => child.NodeType != XmlNodeType.Comment).ToList();
 
-                foreach (XmlNode child in children) {
+              foreach (XmlNode child in children) {
                 if (child.LocalName == "Reference") {
                   foreach (XmlNode childMetadata in child.ChildNodes) {
                     var assemblyPath = Path.GetFullPath (

--- a/PlgxTools/Program.cs
+++ b/PlgxTools/Program.cs
@@ -9,6 +9,7 @@ using KeePassLib.Utility;
 using KeePassLib;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace KeePassPluginDevTools.PlgxTools
 { 
@@ -214,13 +215,11 @@ namespace KeePassPluginDevTools.PlgxTools
             // include all of the project files unless specifically excluded
             var itemGroups = project.GetElementsByTagName ("ItemGroup");
             foreach (XmlNode itemGroup in itemGroups) {
-              // make copy of nodes so that we can delete them inside of the for
+              // make copy of nodes except comments so that we can delete them inside of the for
               // loop if we need to
-              var children = new List<XmlNode> ();
-              foreach (XmlNode child in itemGroup.ChildNodes) {
-                children.Add (child);
-              }
-              foreach (XmlNode child in children) {
+              var children = itemGroup.ChildNodes.Cast<XmlNode>().Where(child => child.NodeType != XmlNodeType.Comment).ToList();
+
+                foreach (XmlNode child in children) {
                 if (child.LocalName == "Reference") {
                   foreach (XmlNode childMetadata in child.ChildNodes) {
                     var assemblyPath = Path.GetFullPath (


### PR DESCRIPTION
PlgxTools.exe fails when there are XML comments `<!-- -->` into `<ItemGroup>` sections in the plugin _.csproj_ file. I have applied a little fix to the build process to skip comments.

The original solution was not compiling in Visual Studio 2017 due to incapability to locate xsd.exe. Moreover, the initial _.csproj_ setup seemed to have issues passing property group value across targes. Not sure whether it was due to changes with Visual Studio 2017. Anyhow, I have fixed all those little issues. 

Please let me know whether the changes look good to you and whether you a new NuGet package with the updates should be released.
